### PR TITLE
 Added support for namesOfParam, unitOfParam, and expressonOfParam to…

### DIFF
--- a/ParameterIO.bundles/Contents/ParameterIO.py~
+++ b/ParameterIO.bundles/Contents/ParameterIO.py~
@@ -188,17 +188,12 @@ def writeParametersToFile(filePath):
    
 def updateParameter(design, paramsList, row):
     # get the values from the csv file.
-        try:
+    try:
         nameOfParam = row[0].strip()
-        nameOfParam = nameOfParam.replace(" ", "") # remove interior spaces
         unitOfParam = row[1].strip()
-        unitOfParam = unitOfParam.replace(" ", "")
         expressionOfParam = row[2].strip()
-        expressionOfParam = expressionOfParam.replace(" ", "");
         try:
             commentOfParam = row[3].strip()
-
-
         except:
             commentOfParam = ''
     except Exception as e:


### PR DESCRIPTION
… include spaces (lines 193, 195, and 197). Tested using Fusion 360 and works well, if people have variable names that are more descriptive than one word